### PR TITLE
collation Use param if present, default to historic val

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ steps:
 |-|:-:|:-:|-|
 | `connection-string-env-var` | Yes | - | Environment variable name that will be filled with the SQL connection string, which can then be used in successive steps. |
 | `catalog` | No | `nservicebus` | The default catalog, which will be created by the action. |
+| `collation` | No | `SQL_Latin1_General_CP1_CS_AS` | Override to any availavble [SQL collation.](https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver17)|
 | `sqlserver-version` | No | "2022" | The SQL server major version to use. |
 | `extra-params` | No | - | Extra parameters to be appended to the end of the connection string |
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ steps:
 |-|:-:|:-:|-|
 | `connection-string-env-var` | Yes | - | Environment variable name that will be filled with the SQL connection string, which can then be used in successive steps. |
 | `catalog` | No | `nservicebus` | The default catalog, which will be created by the action. |
-| `collation` | No | `SQL_Latin1_General_CP1_CS_AS` | Override to any availavble [SQL collation.](https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver17)|
-| `sqlserver-version` | No | "2022" | The SQL server major version to use. |
-| `extra-params` | No | - | Extra parameters to be appended to the end of the connection string |
+| `collation` | No | `SQL_Latin1_General_CP1_CS_AS` | The collation to use for the SQL Server database. Override to any available [SQL collation](https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support). |
+| `sqlserver-version` | No | `2022` | The SQL server major version to use. |
+| `extra-params` | No | - | Extra parameters to be appended to the end of the connection string. |
 
 ## Using `sqlcmd`
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     default: nservicebus
   collation:
-    description: Override to change from Latinq case sensitive, i.e. SQL Azure uses SQL_Latin1_General_CP1_CI_AS insensitive
+    description: The collation to use for the SQL Server database
     required: false
     default: "SQL_Latin1_General_CP1_CS_AS"
   sqlserver-version:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Install SQL Server (Windows)
       if: runner.os == 'Windows'
-      shell: pwsh 
+      shell: pwsh
       run: |
         # Windows SQL install via Chocolatey
         $template = @'
@@ -53,13 +53,13 @@ runs:
         Write-Output "Setting environment variable ${{ inputs.connection-string-env-var }} to SQL connection string..."
         Write-Output "${{ inputs.connection-string-env-var }}=Data Source=.\SQLEXPRESS;Initial Catalog=${{ inputs.catalog }};Integrated Security=True;Encrypt=false;${{ inputs.extra-params }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
     - name: Start SQL Server (Linux)
-      if: runner.os == 'Linux'              
-      shell: bash         
+      if: runner.os == 'Linux'
+      shell: bash
       run: |
         # Linux SQL install via Docker
-        
+
         # If the password generator needs to be changed, make sure the resulting password meets SQL Server password requirements
-        sa_pw=$(uuidgen) 
+        sa_pw=$(uuidgen)
         echo "::add-mask::$sa_pw"
 
         echo "Starting SQL Server in a Docker container..."
@@ -71,7 +71,7 @@ runs:
                    -e "SQLCMDUSER=sa" \
                    -e "SQLCMDPASSWORD=$sa_pw" \
                    -p 1433:1433 --name sqlserver -d mcr.microsoft.com/mssql/server:${{ inputs.sqlserver-version }}-latest
-        
+
         echo "Creating `sqlcmd` bash script to forward commands via docker exec"
         mkdir -p ~/bin
         cat << 'EOF' > ~/bin/sqlcmd
@@ -86,7 +86,7 @@ runs:
         echo "$HOME/bin" >> $GITHUB_PATH
 
         echo "Setting environment variable ${{ inputs.connection-string-env-var }} to SQL connection string..."
-        echo "${{ inputs.connection-string-env-var }}=Server=localhost;Database=${{ inputs.catalog }};User Id=sa;Password=$sa_pw;Encrypt=false;${{ inputs.extra-params }}" >> $GITHUB_ENV  
+        echo "${{ inputs.connection-string-env-var }}=Server=localhost;Database=${{ inputs.catalog }};User Id=sa;Password=$sa_pw;Encrypt=false;${{ inputs.extra-params }}" >> $GITHUB_ENV
     - name: Setup server
       shell: pwsh
       run: |

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: Name of the initial database name (catalog) to create
     required: false
     default: nservicebus
+  collation:
+    description: Override to change from Latinq case sensitive, i.e. SQL Azure uses SQL_Latin1_General_CP1_CI_AS insensitive
+    required: false
+    default: "SQL_Latin1_General_CP1_CS_AS"
   sqlserver-version:
     description: The SQL server major version to use
     required: false
@@ -62,7 +66,7 @@ runs:
         docker run -e "ACCEPT_EULA=Y" \
                    -e "SA_PASSWORD=$sa_pw" \
                    -e "MSSQL_PID=Developer" \
-                   -e "MSSQL_COLLATION=SQL_Latin1_General_CP1_CS_AS" \
+                   -e "MSSQL_COLLATION=${{ inputs.collation }}" \
                    -e "SQLCMDSERVER=localhost" \
                    -e "SQLCMDUSER=sa" \
                    -e "SQLCMDPASSWORD=$sa_pw" \


### PR DESCRIPTION
Use configuration parameter set in collation otherwise default to prior case sensitive collation SQL_Latin1_General_CP1_CS_AS

Background:
SQL Azure used case insensitive collation and when using the tempdb during tests there are cases where joins fail if collation does not match insensitive 🤯 .

@matte created new branch to add some small adjustments. This PR supersedes:

- #26.
