### PR TITLE
Trying out WSL updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup WSL
-        uses: Particular/setup-wsl-action@v1.0.0
+        uses: Particular/setup-wsl-action@fix/docker-subnet-collision
       - name: Run
         uses: ./
         with:
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup WSL
-        uses: Particular/setup-wsl-action@v1.0.0
+        uses: Particular/setup-wsl-action@fix/docker-subnet-collision
       - name: Run with FTS
         uses: ./
         with:
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup WSL
-        uses: Particular/setup-wsl-action@v1.0.0
+        uses: Particular/setup-wsl-action@fix/docker-subnet-collision
       - name: Run with distributed transactions
         uses: ./
         with:


### PR DESCRIPTION
Temp validation PR. Pins `Particular/setup-wsl-action@fix/docker-subnet-collision` so CI exercises the WSL NAT subnet fix end to end.

Why: WSL2 assigns the VM a random subnet from `172.16.0.0/12` on every boot, and Docker's defaults (bridge `172.17.0.0/16`, pools up to `172.30.0.0/16`) sit inside that range. When the NAT lands on `172.17.x`, host->container port publishing breaks (e.g. `MQRC_HOST_NOT_AVAILABLE`). The fix pins Docker's bridge and network pools to `10.x` via `/etc/docker/daemon.json`.

Will be reverted to the released tag (`v1.1.1`) once the fix is merged and tagged.
